### PR TITLE
Add tab-size support & remove extra Firefox padding

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ var getCaretCoordinatesFn = function (element, position, recalculate) {
   });
 
   if (isFirefox) {
-    style.width = parseInt(computed.width) - 2 + 'px'  // Firefox adds 2 pixels to the padding - https://bugzilla.mozilla.org/show_bug.cgi?id=753662
     // Firefox lies about the overflow property for textareas: https://bugzilla.mozilla.org/show_bug.cgi?id=984275
     if (element.scrollHeight > parseInt(computed.height))
       style.overflowY = 'scroll';

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var properties = [
   'letterSpacing',
   'wordSpacing',
 
-  'tab-size',
+  'tabSize',
   'MozTabSize'
 
 ];

--- a/index.js
+++ b/index.js
@@ -38,7 +38,11 @@ var properties = [
   'textDecoration',  // might not make a difference, but better be safe
 
   'letterSpacing',
-  'wordSpacing'
+  'wordSpacing',
+
+  'tab-size',
+  'MozTabSize'
+
 ];
 
 var isFirefox = !(window.mozInnerScreenX == null);
@@ -73,7 +77,7 @@ var getCaretCoordinatesFn = function (element, position, recalculate) {
       style.overflowY = 'scroll';
   } else {
     style.overflow = 'hidden';  // for Chrome to not render a scrollbar; IE keeps overflowY = 'scroll'
-  }  
+  }
 
   div.textContent = element.value.substring(0, position);
   // the second special handling for input type="text" vs textarea: spaces need to be replaced with non-breaking spaces - http://stackoverflow.com/a/13402035/1269037

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var properties = [
   'borderRightWidth',
   'borderBottomWidth',
   'borderLeftWidth',
+  'borderStyle',
 
   'paddingTop',
   'paddingRight',

--- a/test/index.css
+++ b/test/index.css
@@ -8,4 +8,6 @@ input[type="text"], textarea {
   border: 16px lightblue dotted;  /* needs to be accounted for when returning the final position */
   border-right-width: 24px;       /* discourage naive border arithmetic */
   background: lightyellow;
+  tab-size: 20;
+  -moz-tab-size: 20;
 }


### PR DESCRIPTION
* [CSS3 tab-size](http://caniuse.com/#search=tab-size) support added.
* Removed 2px extra padding in Firefox as it is causing problems with caret positioning, at least in Firefox for Windows. The bug report shows no updates.