### PR TITLE
Allow importing (not using) in non-browser envs

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,9 +48,13 @@ var properties = [
 
 ];
 
-var isFirefox = window.mozInnerScreenX != null;
+var isBrowser = (typeof window !== 'undefined');
+var isFirefox = (isBrowser && window.mozInnerScreenX != null);
 
 function getCaretCoordinates(element, position, options) {
+  if(!isBrowser) {
+    throw new Error('textarea-caret-position#getCaretCoordinates should only be called in a browser');
+  }
 
   var debug = options && options.debug || false;
   if (debug) {
@@ -92,7 +96,7 @@ function getCaretCoordinates(element, position, options) {
   div.textContent = element.value.substring(0, position);
   // the second special handling for input type="text" vs textarea: spaces need to be replaced with non-breaking spaces - http://stackoverflow.com/a/13402035/1269037
   if (element.nodeName === 'INPUT')
-    div.textContent = div.textContent.replace(/\s/g, "\u00a0");
+    div.textContent = div.textContent.replace(/\s/g, '\u00a0');
 
   var span = document.createElement('span');
   // Wrapping must be replicated *exactly*, including when a long word gets
@@ -117,9 +121,9 @@ function getCaretCoordinates(element, position, options) {
   return coordinates;
 }
 
-if (typeof module != "undefined" && typeof module.exports != "undefined") {
+if (typeof module != 'undefined' && typeof module.exports != 'undefined') {
   module.exports = getCaretCoordinates;
-} else {
+} else if(isBrowser){
   window.getCaretCoordinates = getCaretCoordinates;
 }
 


### PR DESCRIPTION
This allows the module to be imported (or required) in a non-browser
(read: nodejs) environment, but throws when getCaretCoordinates is called.

This is especially useful for the React Components use case. Typically a
React Component is defined in a file which includes both render-time and
after-mounting-time dependencies, among which textarea-caret-position.
This patch allows the React Component definition file to be correctly
executed for the purpose of testing or server-side rendering, although it
(correctly) throws when attempting to call getCaretCoordinates.

This commit also fixes minor quoting inconcistencies.