### PR TITLE
computation of top coordinates for input elements when height != line-height

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,8 +111,12 @@ function getCaretCoordinates(element, position, options) {
     top: span.offsetTop + parseInt(computed['borderTopWidth']),
     left: span.offsetLeft + parseInt(computed['borderLeftWidth'])
   };
-  if (element.nodeName === 'INPUT')
-    coordinates.top += (parseInt(computed['height']) - parseInt(computed['line-height'])) / 2;
+  if ( element.nodeName === 'INPUT' ) {
+    // unfortunately, 1.1 is approximate. The real number depends on the browser, the font, the size... and seems to be pretty hard to get using simple commands
+    var le = computed['line-height'].slice(-2) === "px" ? parseInt(computed['line-height'], 10) : 1.1 *  parseInt(computed['font-size'], 10);
+    coordinates.top += (parseInt(computed['height']) - le) / 2;
+  }
+
 
   if (debug) {
     span.style.backgroundColor = '#aaa';

--- a/index.js
+++ b/index.js
@@ -111,6 +111,8 @@ function getCaretCoordinates(element, position, options) {
     top: span.offsetTop + parseInt(computed['borderTopWidth']),
     left: span.offsetLeft + parseInt(computed['borderLeftWidth'])
   };
+  if (element.nodeName === 'INPUT')
+    coordinates.top += (parseInt(computed['height']) - parseInt(computed['line-height'])) / 2;
 
   if (debug) {
     span.style.backgroundColor = '#aaa';

--- a/test/index.html
+++ b/test/index.html
@@ -10,11 +10,8 @@
     <p>Click anywhere in the text to see a red vertical line &ndash; a 1-pixel-thick
     <code>div</code> that should be positioned exactly at the location of the caret.</p>
 
-    <div style="height:48px">
-      <input type="text" size="15" maxlength="240" placeholder="Enter text here" style="height:100%">
-    </div>
-
-    <br/><br/><br/><br/><hr/>
+    <input type="text" size="15" maxlength="240" placeholder="Enter text here">
+    <hr/>
 
     <textarea rows="25" cols="40">
       I threw a wish in the well,
@@ -40,10 +37,21 @@
       But here's my number,
       So call me, maybe!
     </textarea>
+    <hr/>
+
+    <input type="text" size="15" maxlength="240" placeholder="Enter text here" style="line-height:normal;height:50px">
+    <input type="text" size="15" maxlength="240" placeholder="Enter text here" style="height:50px">
 
     <script>
-      ['input[type="text"]', 'textarea'].forEach(function (selector) {
-        var element = document.querySelector(selector);
+      var l = [];
+      for( var s = document.body.getElementsByTagName('input'), i = 0; i < s.length; ++i )
+          l.push( s[ i ] );
+      for( var s = document.body.getElementsByTagName('textarea'), i = 0; i < s.length; ++i )
+          l.push( s[ i ] );
+      console.log(l);
+
+      l.forEach(function (element) {
+          console.log(element);
         var fontSize = getComputedStyle(element).getPropertyValue('font-size');
 
         var rect = document.createElement('div');

--- a/test/index.html
+++ b/test/index.html
@@ -10,9 +10,11 @@
     <p>Click anywhere in the text to see a red vertical line &ndash; a 1-pixel-thick
     <code>div</code> that should be positioned exactly at the location of the caret.</p>
 
-    <input type="text" size="15" maxlength="240" placeholder="Enter text here">
+    <div style="height:48px">
+      <input type="text" size="15" maxlength="240" placeholder="Enter text here" style="height:100%">
+    </div>
 
-    <hr/>
+    <br/><br/><br/><br/><hr/>
 
     <textarea rows="25" cols="40">
       I threw a wish in the well,


### PR DESCRIPTION
Hi there,

Many thanks for this really useful library !

This is a simple addition for the case where `line-height` != `height` with input elements. The case is illustrated in test/index.html. For information, it allowed me to add cursors for multiple users in elements created with [material-ui](https://github.com/callemall/material-ui) :)

Is it OK for you ?