### PR TITLE
INPUT height fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,14 @@ function getCaretCoordinates(element, position, options) {
   if (!debug)
     style.visibility = 'hidden';  // not 'display: none' because we want rendering
 
+  var isInput = element.nodeName === 'INPUT';
   // transfer the element's properties to the div
   properties.forEach(function (prop) {
-    style[prop] = computed[prop];
+    if(isInput && prop === 'lineHeight'){
+      style['lineHeight'] = computed['height']; // text in INPUT is rendered centered
+    } else {
+      style[prop] = computed[prop];
+    }
   });
 
   if (isFirefox) {

--- a/test/index.css
+++ b/test/index.css
@@ -11,3 +11,7 @@ input[type="text"], textarea {
   tab-size: 20;
   -moz-tab-size: 20;
 }
+
+input[type="text"] {
+  height: 3em; /* for INPUT element: force different height than line-height */
+}


### PR DESCRIPTION
The text in input-elements is rendered vertically centered.

Thus the caret-position is misaligned, if the `height` of the input-element is not the same as its `lineHeight`.

As a FIX, set the `lineHeight` to the `height` for input-elements.

A corresponding style was added to the test-page for illustration: without the FIX, the caret-position is not rendered correctly.  

without height-FIX (`height: 3em;`)
![without-height-fix](https://cloud.githubusercontent.com/assets/3603062/23962604/f61978cc-09ae-11e7-94af-440420f7ad24.png)


with height-FIX (`height: 3em;`)
![with-height-fix](https://cloud.githubusercontent.com/assets/3603062/23962603/f6184204-09ae-11e7-8006-a935961c6b5a.png)
