### PR TITLE
Only set white-space on mirrored div for textareas

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ var properties = [
   'textDecoration',  // might not make a difference, but better be safe
 
   'letterSpacing',
+  'whiteSpace',
   'wordSpacing',
 
   'tabSize',
@@ -72,9 +73,10 @@ function getCaretCoordinates(element, position, options) {
   var isInput = element.nodeName === 'INPUT';
 
   // Default textarea styles
-  style.whiteSpace = 'pre-wrap';
-  if (!isInput)
+  if (!isInput) {
+    style.whiteSpace = 'pre-wrap';
     style.wordWrap = 'break-word';  // only for textarea-s
+  }
 
   // Position off-screen
   style.position = 'absolute';  // required to return coordinates properly

--- a/index.js
+++ b/index.js
@@ -110,6 +110,9 @@ function getCaretCoordinates(element, position, options) {
     }
   });
 
+  if (isInput) // force pre instead of pre-wrap on the input mirror
+    style.whiteSpace = 'pre';
+
   if (isFirefox) {
     // Firefox lies about the overflow property for textareas: https://bugzilla.mozilla.org/show_bug.cgi?id=984275
     if (element.scrollHeight > parseInt(computed.height))


### PR DESCRIPTION
This addresses an issue with incorrect top coordinates being returned in cases where the mirrored div wraps hyphenated text.

See issue #51 for context. By only applying the `white-space` property to `textarea` and not `input` it allows people to set a `white-space: nowrap` on the element if we need it. I debated setting it explicitly (since inputs never wrap) but it seemed better to simply allow people to control the property on their own. 